### PR TITLE
switch to using tabs for PRs and issues

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -18,7 +18,7 @@ jobs:
         with:
             channel: 'beta'
       - run: flutter pub get
-      - run: flutter analyze
+      - run: flutter analyze --fatal-infos
       - run: dart format --set-exit-if-changed .
       - run: flutter test
       - run: flutter build web

--- a/lib/firebase.dart
+++ b/lib/firebase.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_database/firebase_database.dart';
+import 'package:github/github.dart';
+
+import 'firebase_options.dart';
+import 'issue_utils.dart';
+import 'pull_request_utils.dart';
+
+Future<void> initFirebase() async {
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+}
+
+Stream<List<User>> streamGooglersFromFirebase() {
+  return FirebaseDatabase.instance
+      .ref()
+      .child('googlers/')
+      .onValue
+      .map((event) => event.snapshot)
+      .where((snapshot) => snapshot.exists)
+      .map((snapshot) => snapshot.value as String)
+      .map((value) =>
+          (jsonDecode(value) as List).map((e) => User.fromJson(e)).toList());
+}
+
+Stream<List<Issue>> streamIssuesFromFirebase() {
+  return FirebaseDatabase.instance
+      .ref()
+      .child('issues/data/')
+      .onValue
+      .map((event) => event.snapshot)
+      .where((snapshot) => snapshot.exists)
+      .map((snapshot) => snapshot.value as Map<String, dynamic>)
+      .map((reposToIssues) => reposToIssues.entries
+          .map(
+            (repoToIssues) => (repoToIssues.value as Map)
+                .values
+                .map((issueJson) => decodeIssue(issueJson))
+                .toList(),
+          )
+          .expand((listOfIssues) => listOfIssues)
+          .toList());
+}
+
+Stream<List<PullRequest>> streamPullRequestsFromFirebase() {
+  return FirebaseDatabase.instance
+      .ref()
+      .child('pullrequests/data/')
+      .onValue
+      .map((event) => event.snapshot)
+      .where((snapshot) => snapshot.exists)
+      .map((snapshot) => snapshot.value as Map<String, dynamic>)
+      .map((reposToPRs) => reposToPRs.entries
+          .map(
+            (repoToPRs) => (repoToPRs.value as Map)
+                .values
+                .map((prJson) => decodePR(prJson))
+                .toList(),
+          )
+          .expand((listOfPRs) => listOfPRs)
+          .toList());
+}

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -10,8 +10,30 @@ class AppModel {
   final ValueNotifier<bool> darkMode = ValueNotifier(true);
 
   final ValueNotifier<List<User>> googlers = ValueNotifier([]);
-  final ValueNotifier<List<Issue>> issues = ValueNotifier([]);
-  final ValueNotifier<List<PullRequest>> pullrequests = ValueNotifier([]);
+
+  ValueNotifier<List<Issue>>? _issues;
+  ValueListenable<List<Issue>> get issues {
+    if (_issues == null) {
+      _issues = ValueNotifier([]);
+      streamIssuesFromFirebase().listen((event) {
+        _issues!.value = event;
+      });
+    }
+
+    return _issues!;
+  }
+
+  ValueNotifier<List<PullRequest>>? _pullrequests;
+  ValueListenable<List<PullRequest>> get pullrequests {
+    if (_pullrequests == null) {
+      _pullrequests = ValueNotifier([]);
+      streamPullRequestsFromFirebase().listen((event) {
+        _pullrequests!.value = event;
+      });
+    }
+
+    return _pullrequests!;
+  }
 
   final Completer<bool> _googlersAvailable = Completer<bool>();
 
@@ -33,16 +55,6 @@ class AppModel {
       if (!_googlersAvailable.isCompleted) _googlersAvailable.complete(true);
 
       googlers.value = event;
-    });
-
-    // issues
-    streamIssuesFromFirebase().listen((event) {
-      issues.value = event;
-    });
-
-    // PRs
-    streamPullRequestsFromFirebase().listen((event) {
-      pullrequests.value = event;
     });
 
     await _googlersAvailable.future;

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:github/github.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'firebase.dart';
+
+class AppModel {
+  final ValueNotifier<bool> darkMode = ValueNotifier(true);
+
+  final ValueNotifier<List<User>> googlers = ValueNotifier([]);
+  final ValueNotifier<List<Issue>> issues = ValueNotifier([]);
+  final ValueNotifier<List<PullRequest>> pullrequests = ValueNotifier([]);
+
+  final Completer<bool> _googlersAvailable = Completer<bool>();
+
+  bool get inited => _googlersAvailable.isCompleted;
+
+  Future<void> init() async {
+    // Init the dark mode value notifier.
+    final prefs = await SharedPreferences.getInstance();
+    darkMode.value = prefs.getBool('darkMode') ?? true;
+    darkMode.addListener(() async {
+      await prefs.setBool('darkMode', darkMode.value);
+    });
+
+    // Populate information from firebase.
+    await initFirebase();
+
+    // googlers
+    streamGooglersFromFirebase().listen((event) {
+      if (!_googlersAvailable.isCompleted) _googlersAvailable.complete(true);
+
+      googlers.value = event;
+    });
+
+    // issues
+    streamIssuesFromFirebase().listen((event) {
+      issues.value = event;
+    });
+
+    // PRs
+    streamPullRequestsFromFirebase().listen((event) {
+      pullrequests.value = event;
+    });
+
+    await _googlersAvailable.future;
+  }
+}

--- a/lib/src/issue_table.dart
+++ b/lib/src/issue_table.dart
@@ -94,7 +94,7 @@ class _IssueTableState extends State<IssueTable> {
                 styleFunction: rowStyle,
               ),
               VTableColumn(
-                label: 'Assingees',
+                label: 'Assignees',
                 width: 120,
                 grow: 0.7,
                 alignment: Alignment.topLeft,
@@ -121,14 +121,14 @@ class _IssueTableState extends State<IssueTable> {
                 grow: 0.8,
                 alignment: Alignment.topLeft,
                 transformFunction: (issue) =>
-                    (issue.labels).map((e) => "'${e.name}'").join(', '),
+                    issue.labels.map((e) => "'${e.name}'").join(', '),
                 renderFunction:
                     (BuildContext context, Issue issue, String out) {
                   return ClipRect(
                     child: Wrap(
                       spacing: 4,
                       runSpacing: 4,
-                      children: (issue.labels).map(LabelWidget.new).toList(),
+                      children: issue.labels.map(LabelWidget.new).toList(),
                     ),
                   );
                 },

--- a/lib/src/pages/homepage.dart
+++ b/lib/src/pages/homepage.dart
@@ -78,7 +78,7 @@ class _MyHomePageState extends State<MyHomePage>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Dart PR Dashboard'),
+        title: const Text('Dart Triage Dashboard'),
         actions: [
           SizedBox.square(
             dimension: 16,

--- a/lib/src/pages/homepage.dart
+++ b/lib/src/pages/homepage.dart
@@ -272,13 +272,11 @@ class _MyHomePageState extends State<MyHomePage>
                 controller: tabController,
                 children: [
                   PullRequests(
-                    pullrequests: widget.appModel.pullrequests,
-                    googlers: widget.appModel.googlers,
+                    appModel: widget.appModel,
                     filterStream: filterStream,
                   ),
                   Issues(
-                    issues: widget.appModel.issues,
-                    googlers: widget.appModel.googlers,
+                    appModel: widget.appModel,
                     filterStream: filterStream,
                   ),
                 ],
@@ -307,22 +305,20 @@ class _MyHomePageState extends State<MyHomePage>
 class PullRequests extends StatelessWidget {
   const PullRequests({
     super.key,
+    required this.appModel,
     required this.filterStream,
-    required this.pullrequests,
-    required this.googlers,
   });
 
-  final ValueNotifier<List<PullRequest>> pullrequests;
-  final ValueNotifier<List<User>> googlers;
+  final AppModel appModel;
   final ValueNotifier<SearchFilter?> filterStream;
 
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: pullrequests,
+      valueListenable: appModel.pullrequests,
       builder: (context, pullrequests, child) {
         return ValueListenableBuilder(
-          valueListenable: googlers,
+          valueListenable: appModel.googlers,
           builder: (context, googlers, child) {
             return PullRequestTable(
               pullRequests: pullrequests,
@@ -339,22 +335,20 @@ class PullRequests extends StatelessWidget {
 class Issues extends StatelessWidget {
   const Issues({
     super.key,
+    required this.appModel,
     required this.filterStream,
-    required this.issues,
-    required this.googlers,
   });
 
-  final ValueNotifier<List<Issue>> issues;
-  final ValueNotifier<List<User>> googlers;
+  final AppModel appModel;
   final ValueNotifier<SearchFilter?> filterStream;
 
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: issues,
+      valueListenable: appModel.issues,
       builder: (context, issues, child) {
         return ValueListenableBuilder(
-          valueListenable: googlers,
+          valueListenable: appModel.googlers,
           builder: (context, googlers, child) {
             return IssueTable(
               issues: issues,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -545,18 +545,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -577,26 +577,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: "67ec5684c7a19b2aba91d2831f3d305a6fd8e1504629c5818f8d64478abf4f38"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.24.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: "6b753899253c38ca0523bb0eccff3934ec83d011705dae717c61ecf209e333c9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.5.4"
   typed_data:
     dependency: transitive
     description:
@@ -669,6 +669,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  url_strategy:
+    dependency: "direct main"
+    description:
+      name: url_strategy
+      sha256: "42b68b42a9864c4d710401add17ad06e28f1c1d5500c93b98c431f6b0ea4ab87"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   vector_math:
     dependency: transitive
     description:
@@ -689,10 +697,10 @@ packages:
     dependency: "direct main"
     description:
       name: vtable
-      sha256: da5d02a14e63c58e359c0d65ae7291f8b478169237ecdc16a8b41f9886bbaacc
+      sha256: "850840a807a7475c373dbc915caf87a3c47eba8877ff9f22dc8556498c68da2f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.1"
+    version: "0.4.0"
   watcher:
     dependency: transitive
     description:
@@ -701,6 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -742,5 +758,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=3.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   github: ^9.11.0
   shared_preferences: ^2.1.0
   url_launcher: ^6.1.10
-  vtable: ^0.3.1
+  url_strategy: ^0.2.0
+  vtable: ^0.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- switch to using tabs for PRs and issues
- move some app state into an 'AppModel' class; this make some of the UI changes above slightly easier (some firebase data was only populated by entering portion of the UI previously)

This was a bigger change than I'd intended but it was easier to make the model changes in order to switch to using tabs. Happy to iterate on this PR / go another way w/ it.

<img width="1388" alt="Screenshot 2023-07-12 at 1 41 14 PM" src="https://github.com/mosuem/dart_pr_dashboard/assets/1269969/9ef8108b-bd2b-4731-ae73-0d48a6d7edf9">

Note that I am seeing an exception when building the screen now; I wasn't able to track down what's causing it:

```
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following assertion was thrown while applying parent data.:
Incorrect use of ParentDataWidget.
The ParentDataWidget Expanded(flex: 1) wants to apply ParentData of type FlexParentData to a
RenderObject, which has been set up to accept ParentData of incompatible type ParentData.
Usually, this means that the Expanded widget has the wrong ancestor RenderObjectWidget. Typically,
Expanded widgets are placed directly inside Flex widgets.
The offending Expanded is currently placed inside a RepaintBoundary widget.
The ownership chain for the RenderObject that received the incompatible parent data was:
  Column ← VTable<PullRequest> ← ValueListenableBuilder<SearchFilter?> ← Expanded ← PullRequestTable
← ValueListenableBuilder<List<User>> ← ValueListenableBuilder<List<PullRequest>> ← PullRequests ←
KeyedSubtree-[<0>] ← RepaintBoundary ← ⋯
```


