### PR TITLE
adjust look and feel for the issues table

### DIFF
--- a/lib/issue_utils.dart
+++ b/lib/issue_utils.dart
@@ -29,4 +29,13 @@ extension IssueUtils on Issue {
   }
 
   bool authorIsGoogler(Set<String> googlers) => googlers.contains(user?.login);
+
+  String? get repoSlug {
+    final url = repositoryUrl;
+    if (url == null) return null;
+
+    const marker = '/repos/';
+    final index = url.indexOf(marker);
+    return index == -1 ? null : url.substring(index + marker.length);
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,7 +60,9 @@ class _MyAppState extends State<MyApp> {
 
         return MaterialApp(
           title: appName,
-          theme: value ? ThemeData.dark() : ThemeData.light(),
+          theme: value
+              ? ThemeData.dark(useMaterial3: false)
+              : ThemeData.light(useMaterial3: false),
           debugShowCheckedModeBanner: false,
           home: content,
         );

--- a/lib/src/pullrequest_table.dart
+++ b/lib/src/pullrequest_table.dart
@@ -6,6 +6,7 @@ import 'package:vtable/vtable.dart';
 import '../pull_request_utils.dart';
 import 'filter/filter.dart';
 import 'misc.dart';
+import 'widgets.dart';
 
 class PullRequestTable extends StatefulWidget {
   final List<PullRequest> pullRequests;
@@ -41,7 +42,6 @@ class _PullRequestTableState extends State<PullRequestTable> {
         return VTable<PullRequest>(
           items: pullRequests,
           tableDescription: '${pullRequests.length} PRs',
-          rowHeight: 64.0,
           includeCopyToClipboardAction: true,
           onDoubleTap: (pr) => launchUrl(Uri.parse(pr.htmlUrl!)),
           columns: [
@@ -52,6 +52,9 @@ class _PullRequestTableState extends State<PullRequestTable> {
               alignment: Alignment.topLeft,
               transformFunction: (pr) => pr.titleDisplay,
               styleFunction: rowStyle,
+              renderFunction: (context, PullRequest pr, String out) {
+                return textTwoLines(out);
+              },
             ),
             VTableColumn(
               label: 'Repo',
@@ -162,39 +165,6 @@ TextStyle? rowStyle(PullRequest pr) {
   if (pr.authorIsCopybara) return draftPrStyle;
 
   return null;
-}
-
-class LabelWidget extends StatelessWidget {
-  final IssueLabel label;
-
-  const LabelWidget(
-    this.label, {
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final chipColor = Color(int.parse('FF${label.color}', radix: 16));
-
-    return Material(
-      color: chipColor,
-      shape: const StadiumBorder(),
-      elevation: 2,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6.0),
-        child: Text(
-          label.name,
-          style: TextStyle(
-            color: isLightColor(chipColor)
-                ? Colors.grey.shade900
-                : Colors.grey.shade100,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-      ),
-    );
-  }
 }
 
 ValidationResult? needsReviewersValidator(

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -32,7 +32,8 @@ class LabelWidget extends StatelessWidget {
                 ? Colors.grey.shade900
                 : Colors.grey.shade100,
           ),
-          textScaler: const TextScaler.linear(0.75),
+          textScaleFactor: 0.75,
+          // textScaler: const TextScaler.linear(0.75),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:github/github.dart';
+
+import 'misc.dart';
+
+Text textTwoLines(String text) {
+  return Text(text, maxLines: 2, overflow: TextOverflow.ellipsis);
+}
+
+class LabelWidget extends StatelessWidget {
+  final IssueLabel label;
+
+  const LabelWidget(
+    this.label, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final chipColor = Color(int.parse('FF${label.color}', radix: 16));
+
+    return Material(
+      color: chipColor,
+      shape: const StadiumBorder(),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6.0),
+        child: Text(
+          label.name,
+          style: TextStyle(
+            color: isLightColor(chipColor)
+                ? Colors.grey.shade900
+                : Colors.grey.shade100,
+          ),
+          textScaler: const TextScaler.linear(0.75),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,6 +264,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   firebase_core: ^2.9.0
   firebase_database: ^10.1.0
   github: ^9.11.0
+  intl: ^0.18.1
   shared_preferences: ^2.1.0
   url_launcher: ^6.1.10
   url_strategy: ^0.2.0


### PR DESCRIPTION
Adjust look and feel for the issues table:

- use the full slug of the repo (`owner/name`) for similarity with the PR tabel
- revert to pre-material 3 (we'll need to update some foreground and background colors)
- make rows two lines high and reduce the sizes of the label widgets
