### PR TITLE
fix the display of PR repo info

### DIFF
--- a/pkgs/dart_pr_dashboard/lib/src/pullrequest_table.dart
+++ b/pkgs/dart_pr_dashboard/lib/src/pullrequest_table.dart
@@ -67,7 +67,7 @@ class _PullRequestTableState extends State<PullRequestTable> {
               grow: 0.5,
               alignment: Alignment.topLeft,
               transformFunction: (PullRequest pr) =>
-                  pr.base?.repo?.slug().fullName ?? '',
+                  pr.repoSlug?.fullName ?? '',
               styleFunction: rowStyle,
             ),
             VTableColumn(

--- a/pkgs/dart_triage_updater/lib/pull_request_utils.dart
+++ b/pkgs/dart_triage_updater/lib/pull_request_utils.dart
@@ -21,4 +21,12 @@ extension ReviewerAddition on PullRequest {
   bool authorIsGoogler(Set<String> googlers) => googlers.contains(user?.login);
 
   bool get authorIsCopybara => user?.login == 'copybara-service[bot]';
+
+  RepositorySlug? get repoSlug {
+    final url = htmlUrl;
+    if (url == null) return null;
+
+    final pathParts = Uri.parse(url).pathSegments;
+    return RepositorySlug(pathParts[0], pathParts[1]);
+  }
 }


### PR DESCRIPTION
- fix the display of PR repo info

Both PullRequest.repo and PullRequest.base.repo seem to be `null`.